### PR TITLE
v1.0.0: `execute()` returns an error and a result

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,13 @@ Sap.prototype.execute = function (method, path, params, callback) {
     };
 
     request(options, function (err, res, body) {
-      callback(err, res, body);
+      if (err) {
+        callback(err);
+      } else if (!err && res.statusCode !== 200) {
+        callback(new Error('Received a ' + res.statusCode + ' error'));
+      } else {
+        callback(null, JSON.parse(body));
+      }
     });
   }, function (err) {
     callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sap",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "SAP Anywhere API integration tool",
   "author": "Daryl Rodrigo <daryl@pi-top.com>",
   "contributors": [

--- a/test/integrationTests.js
+++ b/test/integrationTests.js
@@ -11,11 +11,7 @@ describe('Integration tests', function () {
   describe('execute', function () {
     // Enable tests by removing the 'x' in front of the line below
     xit('sends custom HTTP requests', function (done) {
-      sap.execute('GET', 'Currencies', null, function (err, res, body) {
-        var data;
-        if (body) data = JSON.parse(body);
-
-        expect(res.statusCode).to.equal(200);
+      sap.execute('GET', 'Currencies', null, function (err, data) {
         expect(data.length).to.be.above(0);
         expect(data.error).not.to.exist;
         done();

--- a/test/unitTests.js
+++ b/test/unitTests.js
@@ -78,9 +78,8 @@ describe('Unit tests', function () {
     });
 
     it('passes the response to the callback', function (done) {
-      sap.execute('GET', path, null, function (err, res, body) {
-        expect(res.statusCode).to.equal(statusCode);
-        expect(JSON.parse(body)).to.eql(expectedResult);
+      sap.execute('GET', path, null, function (err, data) {
+        expect(data).to.eql(expectedResult);
         done();
       });
     });


### PR DESCRIPTION
Instead of passing `(err, res, body)` to the callback - where `body` is a JSON string - the `execute()` function now returns an `error` object or a `data` object. Fixes #9 